### PR TITLE
add necessary chromium options to electron

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -15,6 +15,9 @@ const installExtensions = async () => {
     .catch(console.log);
 };
 
+app.commandLine.appendSwitch('--touch-events');
+app.commandLine.appendSwitch('--enable-transparent-visuals');
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow


### PR DESCRIPTION
The followings are added as default for electron based launch.

 --touch-events
 --enable-transparent-visuals

