### PR TITLE
change component tree to conform flexbox rule

### DIFF
--- a/src/components/AnimatedFlake.js
+++ b/src/components/AnimatedFlake.js
@@ -5,6 +5,7 @@ import { func, object } from 'prop-types';
 import Image from './Image';
 import Video from './Video';
 import Motion from './Motion';
+import StyledFlake from './StyledFlake';
 import * as animeMethods from '../libs/anime-methods';
 
 class AnimatedFlake extends React.Component {
@@ -18,6 +19,12 @@ class AnimatedFlake extends React.Component {
         option: props.option
       });
     }
+
+    this.styleParam = {
+      option: props.option,
+      style: props.item.style,
+      order: props.item.id
+    };
   }
 
   componentDidMount() {
@@ -43,27 +50,29 @@ class AnimatedFlake extends React.Component {
   render() {
     let { item, option } = this.props;
 
-    const getContent = (target) => {
+    const getContent = (content) => {
       let ContentComponent = <div />;
 
-      if (target.type === 'image') {
+      if (content.type === 'image') {
         ContentComponent = Image;
-      } else if (target.type === 'video') {
+      } else if (content.type === 'video') {
         ContentComponent = Video;
-      } else if (target.type === 'motion') {
+      } else if (content.type === 'motion') {
         ContentComponent = Motion;
       } else {
-        console.error('This content is not supported: ', target.type);
+        console.error('This content is not supported: ', content.type);
       }
 
-      return <ContentComponent refCallback={el => this.contentElements.push(el)} key={target.id} option={target} />
+      return <ContentComponent refCallback={el => this.contentElements.push(el)} key={content.id} option={content} />
     }
 
     const contents = item.contents.sort((a, b) => { return a.id - b.id });
 
     return (
       <div {...this.listeners}>
-        { contents.map(getContent) }
+        <StyledFlake {...this.styleParam}>
+          { contents.map(getContent) }
+        </StyledFlake>
       </div>
     );
   }

--- a/src/components/AnimatedLayout.js
+++ b/src/components/AnimatedLayout.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { array, object } from 'prop-types';
 import Flake from './Flake';
 import * as animeMethods from '../libs/anime-methods';
+import StyledLayout from './StyledLayout';
 
 class AnimatedLayout extends React.Component {
   flakeElements = [];
@@ -27,7 +28,8 @@ class AnimatedLayout extends React.Component {
   }
 
   render() {
-    return <div>
+    return (
+      <StyledLayout>
       {
         this.props.items.map(item => 
           <Flake 
@@ -39,7 +41,8 @@ class AnimatedLayout extends React.Component {
           </Flake>
         )
       }
-    </div>
+      </StyledLayout>
+    );
   }
 }
 

--- a/src/components/Background.js
+++ b/src/components/Background.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { array, object } from 'prop-types';
+import { object } from 'prop-types';
 import StyledBackground from './StyledBackground';
 import Flake from './Flake';
 
@@ -7,7 +7,7 @@ const Background = (props) => {
   return (
     <StyledBackground>
       <Flake
-        refCallback={() => console.log('bg flake')}
+        refCallback={(el) => console.log('bg flake')}
         item={props.currentItem}
         option={props.option}
         listeners={props.listeners}>

--- a/src/components/Flake.js
+++ b/src/components/Flake.js
@@ -1,21 +1,12 @@
 import React from 'react';
 import ReactTransitionGroup from 'react-addons-transition-group';
-import StyledFlake from './StyledFlake';
 import AnimatedFlake from './AnimatedFlake';
 
 const Flake = (props) => {
-  const param = {
-    option: props.option,
-    style: props.item.style,
-    order: props.item.id
-  };
-
   return (
-    <StyledFlake {...param}>
-      <ReactTransitionGroup key="AnimatedFlake">
-        <AnimatedFlake {...props} />
-      </ReactTransitionGroup>
-    </StyledFlake>
+    <ReactTransitionGroup key="AnimatedFlake" component="div">
+      <AnimatedFlake {...props} />
+    </ReactTransitionGroup>
   );
 }
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -2,14 +2,13 @@ import React from 'react';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import StyledLayout from './StyledLayout';
 import AnimatedLayout from './AnimatedLayout';
+import Flake from './Flake';
 
 const Layout = (props) => {
   return (
-    <StyledLayout>
-      <ReactTransitionGroup key="AnimatedLayout">
-        <AnimatedLayout {...props} />
-      </ReactTransitionGroup>
-    </StyledLayout>
+    <ReactTransitionGroup key="AnimatedLayout">
+      <AnimatedLayout {...props} />
+    </ReactTransitionGroup>
   );
 }
 

--- a/src/components/StyledFlake.js
+++ b/src/components/StyledFlake.js
@@ -9,8 +9,8 @@ const StyledFlake = ({option, style, order, children}) => {
     background-color: red;
     order: ${order};
     flex-grow: 0;
-    ${option.size === 'fitted' ? 'width: 100%; height: 100%;': ''}
     width: ${option.size !== undefined ? option.size : 150}px;
+    ${option.size === 'fitted' ? 'width: 100vw; height: 100vh;': ''}
     margin: ${option.margin !== undefined ? option.margin : 20}px;
   `;
 


### PR DESCRIPTION
Flexbox container (parent) must not have div child element which wraps all flex items of parent.
We have changed component tree to conform this flexbox rule, so that this fixed flexbox items not prositioned properly.

- components for layout

```
<ReactTransitionGroup>
 <AnimatedLayout>  <---- container which defines react transition event handlers
  <StyledLayout>   <---- flexbox container (parent)
   <Flake />       <---- flexbox item 
   <Flake />       <---- flexbox item
  </StyledLayout>
 </AnimatedLayout>
</ReactTransitionGroup>
```

This commit include change of component tree for a flake, not related to flexbox.

```
<ReactTransitionGroup>
 <AnimatedFlake>
  <StyledFlake>
   <Image />
   <Video />
   <Motion />
  </StyledFlake>
 </AnimatedFlake>
</ReactTransitionGroup>
```
